### PR TITLE
Add providers service and allow partial updates

### DIFF
--- a/app/Models/System/Provider.php
+++ b/app/Models/System/Provider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\\Models\\System;
+
+use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;
+use Illuminate\\Database\\Eloquent\\Model;
+
+class Provider extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'driver',
+        'api_url',
+        'api_key',
+        'is_active',
+    ];
+}

--- a/app/Services/Providers/ProvidersService.php
+++ b/app/Services/Providers/ProvidersService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Providers;
+
+use App\Models\System\Provider;
+use Illuminate\Support\Facades\Validator;
+
+class ProvidersService
+{
+    /**
+     * Remove extra whitespace from string payload values when present.
+     */
+    public function cleanupPayload(array $payload): array
+    {
+        foreach (['name', 'api_url', 'api_key', 'driver'] as $key) {
+            if (array_key_exists($key, $payload) && is_string($payload[$key])) {
+                $payload[$key] = trim($payload[$key]);
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Validate provider data for create/update operations.
+     */
+    public function saveValidate(array $data, ?Provider $model = null): array
+    {
+        $requiredRule = $model === null ? 'required' : 'sometimes|required';
+
+        $rules = [
+            'name' => [$requiredRule, 'string', 'max:255'],
+            'api_url' => [$requiredRule, 'string', 'max:2048'],
+            'api_key' => [$requiredRule, 'string', 'max:255'],
+            'driver' => [$requiredRule, 'string', 'max:255'],
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+
+        return Validator::make($data, $rules)->validate();
+    }
+
+    /**
+     * Update an existing provider with the supplied payload.
+     */
+    public function edit(Provider $provider, array $data): Provider
+    {
+        $payload = $this->cleanupPayload($data);
+
+        $validated = $this->saveValidate($payload, $provider);
+
+        $provider->fill($validated);
+        $provider->save();
+
+        return $provider;
+    }
+
+    public function activate(Provider $provider): Provider
+    {
+        return $this->edit($provider, ['is_active' => true]);
+    }
+
+    public function deactivate(Provider $provider): Provider
+    {
+        return $this->edit($provider, ['is_active' => false]);
+    }
+
+    public function create(array $data): Provider
+    {
+        $payload = $this->cleanupPayload($data);
+        $validated = $this->saveValidate($payload);
+
+        if (!array_key_exists('is_active', $validated)) {
+            $validated['is_active'] = true;
+        }
+
+        return Provider::create($validated);
+    }
+}

--- a/database/factories/System/ProviderFactory.php
+++ b/database/factories/System/ProviderFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\\Factories\\System;
+
+use App\\Models\\System\\Provider;
+use Illuminate\\Database\\Eloquent\\Factories\\Factory;
+
+/**
+ * @extends Factory<Provider>
+ */
+class ProviderFactory extends Factory
+{
+    protected $model = Provider::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'driver' => $this->faker->slug(),
+            'api_url' => $this->faker->url(),
+            'api_key' => $this->faker->sha1(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/migrations/2025_09_20_120000_create_providers_table.php
+++ b/database/migrations/2025_09_20_120000_create_providers_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('providers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('driver');
+            $table->string('api_url');
+            $table->string('api_key');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('providers');
+    }
+};

--- a/tests/Feature/Providers/ProvidersServiceTest.php
+++ b/tests/Feature/Providers/ProvidersServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\\Feature\\Providers;
+
+use App\\Models\\System\\Provider;
+use App\\Services\\Providers\\ProvidersService;
+use Illuminate\\Foundation\\Testing\\RefreshDatabase;
+use Tests\\TestCase;
+
+class ProvidersServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_provider_status_can_be_toggled_without_full_payload(): void
+    {
+        $service = new ProvidersService();
+
+        $provider = Provider::factory()->create([
+            'name' => 'Example Provider',
+            'driver' => 'example-driver',
+            'api_url' => 'https://example.test',
+            'api_key' => 'secret',
+            'is_active' => true,
+        ]);
+
+        $service->edit($provider, ['is_active' => false]);
+        $this->assertFalse($provider->fresh()->is_active);
+
+        $service->edit($provider, ['is_active' => true]);
+        $this->assertTrue($provider->fresh()->is_active);
+    }
+}


### PR DESCRIPTION
## Summary
- add a providers service capable of trimming payload strings only when provided and validating create vs update payloads
- introduce a Provider model, migration, and factory to persist provider configuration with active flag
- cover provider status toggling via a new feature test ensuring partial updates succeed without resubmitting full payload

## Testing
- ⚠️ `composer install` *(fails: GitHub 403 CONNECT tunnel when downloading symfony/finder without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d1337581508331be3aa8542394c11e