### PR TITLE
Add service importer persistence for manual activation state

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,13 @@
+APP_KEY=base64:pIbALfI/HwuwRx6BcjnnuUN9FKJQ5T+hHeApbGeALdQ=
+APP_ENV=testing
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+DB_FOREIGN_KEYS=true
+
+CACHE_DRIVER=array
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=array
+MAIL_MAILER=array

--- a/app/Models/Services/Service.php
+++ b/app/Models/Services/Service.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\Services;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Service extends Model
+{
+    use HasFactory;
+
+    protected $table = 'services';
+
+    protected $fillable = [
+        'external_id',
+        'name',
+        'is_active',
+        'meta',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'meta' => 'array',
+    ];
+}

--- a/app/Services/Services/ServiceImporter.php
+++ b/app/Services/Services/ServiceImporter.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\Services;
+
+use App\Models\Services\Service;
+use Illuminate\Support\Arr;
+
+class ServiceImporter
+{
+    public function import(array $services): void
+    {
+        foreach ($services as $payload) {
+            $externalId = Arr::get($payload, 'id');
+
+            if ($externalId === null) {
+                continue;
+            }
+
+            $service = Service::query()->firstOrNew([
+                'external_id' => (string) $externalId,
+            ]);
+
+            if (Arr::has($payload, 'name')) {
+                $service->name = Arr::get($payload, 'name');
+            }
+
+            $meta = $service->meta;
+            $previousProviderPayload = $meta['provider_payload'] ?? [];
+            $previousProviderAvailability = $this->extractAvailability($previousProviderPayload);
+
+            $meta['provider_payload'] = $this->mergeProviderPayload($previousProviderPayload, $payload);
+            $service->meta = $meta;
+
+            $currentProviderAvailability = $this->extractAvailability($service->meta['provider_payload']);
+            $availabilityFlagProvided = $this->hasAvailabilityFlag($payload);
+
+            if (! $service->exists) {
+                $service->is_active = $currentProviderAvailability !== false;
+            } elseif ($availabilityFlagProvided) {
+                if ($currentProviderAvailability === true && $previousProviderAvailability === false) {
+                    $service->is_active = true;
+                }
+
+                if ($currentProviderAvailability === false) {
+                    $service->is_active = false;
+                }
+            }
+
+            $service->save();
+        }
+    }
+
+    private function extractAvailability(array $payload): ?bool
+    {
+        foreach (['available', 'is_available', 'is_active'] as $key) {
+            if (array_key_exists($key, $payload)) {
+                $value = $payload[$key];
+
+                if ($value === null) {
+                    return null;
+                }
+
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function hasAvailabilityFlag(array $payload): bool
+    {
+        foreach (['available', 'is_available', 'is_active'] as $key) {
+            if (array_key_exists($key, $payload)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function mergeProviderPayload(array $previous, array $current): array
+    {
+        foreach ($current as $key => $value) {
+            $previous[$key] = $value;
+        }
+
+        return $previous;
+    }
+}

--- a/database/migrations/2025_09_21_000200_create_services_table.php
+++ b/database/migrations/2025_09_21_000200_create_services_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('services', function (Blueprint $table) {
+            $table->id();
+            $table->string('external_id')->unique();
+            $table->string('name');
+            $table->boolean('is_active')->default(true);
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('services');
+    }
+};

--- a/tests/Feature/Admin/ServicesManagementTest.php
+++ b/tests/Feature/Admin/ServicesManagementTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Services\Service;
+use App\Services\Services\ServiceImporter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServicesManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_manual_deactivation_survives_import(): void
+    {
+        $importer = new ServiceImporter();
+
+        $payload = [
+            [
+                'id' => 'srv-1',
+                'name' => 'Example service',
+                'available' => true,
+            ],
+        ];
+
+        $importer->import($payload);
+
+        $service = Service::query()->firstOrFail();
+        $this->assertTrue($service->is_active);
+        $this->assertSame($payload[0], $service->meta['provider_payload']);
+
+        $service->update(['is_active' => false]);
+
+        $importer->import([
+            [
+                'id' => 'srv-1',
+                'name' => 'Example service',
+            ],
+        ]);
+
+        $service->refresh();
+        $this->assertFalse($service->is_active);
+        $this->assertSame('Example service', $service->name);
+        $this->assertSame('srv-1', $service->external_id);
+    }
+}


### PR DESCRIPTION
## Summary
- add a services table and Eloquent model to persist provider metadata
- update the service importer to keep manual is_active overrides unless the provider explicitly marks availability
- cover the regression with an admin services management feature test
- configure a dedicated testing environment using sqlite

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d19f4f68a48331a682f2823ace4f43